### PR TITLE
Update README for python 3

### DIFF
--- a/web/README.txt
+++ b/web/README.txt
@@ -1,3 +1,8 @@
-Copy the `textures` folder from the default Minecraft resource pack to this directory, then host this folder with `python -m SimpleHTTPServer` to open the index.html file.
+Copy the `textures` folder from the default Minecraft resource pack to this directory, then host this folder using the following commands to open the index.html file:
+
+If you're on Python 2: `python -m SimpleHTTPServer`
+
+If you're on Python 3: `python -m http.server`
+*Note: depending on how Python was installed, you may have to do `python3 -m http.server` instead.
 
 You can import inventories from ../lib/inventories.mjs


### PR DESCRIPTION
``SimpleHTTPServer`` no longer exists in Python 3 (it has been merged into ``http.server``).